### PR TITLE
chore: preserve original author name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 MIT License
 
+Copyright (c) 2024 Edoardo Scibona
 Copyright (c) 2024 Atahan Yorgancı
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Hi,

I am the original author of `query-registry`, which you forked. Forking is allowed by the MIT license and I'm fine with that but you must preserve the original copyright notice:

> The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.

See also https://softwareengineering.stackexchange.com/questions/386582/altering-author-names-in-mit-license.

This PR adds the original copyright notice back to the license file.
